### PR TITLE
Fix issues with null terminator in resolved path

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -90,7 +90,7 @@ const plugin = ({
 
         if (resolved) {
           return {
-            path: resolved,
+            path: resolved.replace(/\0/g, ''),
           };
         }
       });


### PR DESCRIPTION
Thanks for this plugin, it's been a life saver.

I ran into webpack/enhanced-resolve#282 and was able to work around it with this fix removing null terminators from the path, which, I can't imagine ever wanting.