### PR TITLE
Account for the presence of exports for browser

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -56,9 +56,12 @@ const plugin = ({
           conditionNames:
             build.initialOptions.conditions ??
             pick({
+              browser: isBrowser,
+              module: isBrowser && isImport,
               import: isImport,
               require: isRequire,
               node: isNode,
+              default: true,
             }),
           mainFields:
             build.initialOptions.mainFields ??


### PR DESCRIPTION
This was a weird one. I was esbuilding for `platform: browser`, but it was always resolving the node exports.

Here's the [package.json](https://github.com/JSONPath-Plus/JSONPath/blob/v5.1.0/package.json#L5-L17) in question:

```json
  "main": "dist/index-node-cjs.js",
  "exports": {
    "./package.json": "./package.json",
    ".": {
      "browser": "./dist/index-browser-esm.js",
      "umd": "./dist/index-browser-umd.js",
      "import": "./dist/index-node-esm.mjs",
      "require": "./dist/index-node-cjs.js",
      "default": "./dist/index-browser-esm.js"
    }
  },
  "module": "dist/index-node-esm.mjs",
  "browser": "dist/index-browser-esm.js",
```

what was happening is that even though there is a `browser` and `exports.".".browser` specified, the plugin was respecting `browser.".".import` first.

Adding these conditions got this to resolve correctly to `./dist/index-browser-esm.js`.
